### PR TITLE
Add CIDR notation for IP range match

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,26 +60,30 @@ displayed on stderr.
     blocked, then shell snippets to set the chosen configuration are displayed.
     
     OPTIONS:
-     -d, --allow-dns           	Allow connections to DNS nameservers.
-     -a, --allow=ADDRESS[:PORT]	Allow connections to ADDRESS[:PORT].
-     -b, --block=ADDRESS[:PORT]	Prevent connections to ADDRESS[:PORT].
-     -h, --help                	Print this help message.
-     -t, --log-target=LOG      	Where to log. LOG is a comma-separated list
-                               	that can contain the following values:
-                               	  - stderr	This is the default
-                               	  - syslog	Write to syslog
-                               	  - file	Write to COMMAND.coc file
-     -p, --log-path=PATH      	Path for file log.
-     -l, --log-level=LEVEL     	What to log. LEVEL can contain one of the
-                               	following values:
-                               	  - silent	Do not log anything
-                               	  - error	Log errors
-                               	  - block	Log errors and blocked
-                               	            connections
-                               	  - allow	Log errors, blocked and
-                               	            allowed connections
-                               	  - debug	Log everything
-    -v, --version             	Print connect-or-cut version.
+     -d, --allow-dns                   	Allow connections to DNS nameservers.
+     -a, --allow=ADDRESS[/BITS][:PORT] 	Allow connections to ADDRESS[/BITS][:PORT].
+     -b, --block=ADDRESS[/BITS][:PORT] 	Prevent connections to ADDRESS[/BITS][:PORT].
+                                       	BITS is the number of bits in CIDR notation
+                                       	prefix. When BITS is specified, the rule
+                                       	matches the IP range.
+     -h, --help                        	Print this help message.
+     -t, --log-target=LOG              	Where to log. LOG is a comma-separated list
+                                       	that can contain the following values:
+                                       	  - stderr      This is the default
+                                       	  - syslog      Write to syslog
+                                       	  - file        Write to COMMAND.coc file
+     -p, --log-path=PATH               	Path for file log.
+     -l, --log-level=LEVEL             	What to log. LEVEL can contain one of the
+                                       	following values:
+                                       	  - silent      Do not log anything
+                                       	  - error       Log errors
+                                       	  - block       Log errors and blocked
+                                       	                connections
+                                       	  - allow       Log errors, blocked and
+                                       	                allowed connections
+                                       	  - debug       Log everything
+     -v, --version                     	Print connect-or-cut version.
+
 
 ## Use cases
 

--- a/coc
+++ b/coc
@@ -85,26 +85,29 @@ If no COMMAND is specified but some addresses are configured to be allowed or
 blocked, then shell snippets to set the chosen configuration are displayed.
 
 OPTIONS:
- -d, --allow-dns           	Allow connections to DNS nameservers.
- -a, --allow=ADDRESS[:PORT]	Allow connections to ADDRESS[:PORT].
- -b, --block=ADDRESS[:PORT]	Prevent connections to ADDRESS[:PORT].
- -h, --help                	Print this help message.
- -t, --log-target=LOG      	Where to log. LOG is a comma-separated list
-                           	that can contain the following values:
-                           	  - stderr	This is the default
-                           	  - syslog	Write to syslog
-                           	  - file	Write to COMMAND.coc file
- -p, --log-path=PATH      	Path for file log.
- -l, --log-level=LEVEL     	What to log. LEVEL can contain one of the
-                           	following values:
-                           	  - silent	Do not log anything
-                           	  - error	Log errors
-                           	  - block	Log errors and blocked
-                           	                connections
-                           	  - allow	Log errors, blocked and
-                           	                allowed connections
-                           	  - debug	Log everything
- -v, --version             	Print connect-or-cut version.
+ -d, --allow-dns                  	Allow connections to DNS nameservers.
+ -a, --allow=ADDRESS[/BITS][:PORT]	Allow connections to ADDRESS[/BITS][:PORT].
+ -b, --block=ADDRESS[/BITS][:PORT]	Prevent connections to ADDRESS[/BITS][:PORT].
+                                  	BITS is the number of bits in CIDR notation
+                                  	prefix. When BITS is specified, the rule
+                                  	matches the IP range.
+ -h, --help                       	Print this help message.
+ -t, --log-target=LOG             	Where to log. LOG is a comma-separated list
+                                  	that can contain the following values:
+                                  	  - stderr	This is the default
+                                  	  - syslog	Write to syslog
+                                  	  - file	Write to COMMAND.coc file
+ -p, --log-path=PATH              	Path for file log.
+ -l, --log-level=LEVEL            	What to log. LEVEL can contain one of the
+                                  	following values:
+                                  	  - silent	Do not log anything
+                                  	  - error	Log errors
+                                  	  - block	Log errors and blocked
+                                  	                connections
+                                  	  - allow	Log errors, blocked and
+                                  	                allowed connections
+                                  	  - debug	Log everything
+ -v, --version                    	Print connect-or-cut version.
 EOF
 }
 

--- a/connect-or-cut.c
+++ b/connect-or-cut.c
@@ -351,7 +351,8 @@ mask_ipv6 (struct in6_addr *addr, const struct in6_addr *netmask)
   uint32_t *_addr = (uint32_t *) addr;
   const uint32_t *_netmask = (uint32_t *) netmask;
 
-  for (int i = 0; i < 4; i++)
+  int i;
+  for (i = 0; i < 4; i++)
     {
       _addr[i] &= _netmask[i];
     }

--- a/connect-or-cut.c
+++ b/connect-or-cut.c
@@ -175,10 +175,15 @@ typedef struct coc_entry {
     struct in6_addr ipv6;
     char *glob;
   } addr;
+  union {
+    struct in_addr ipv4;
+    struct in6_addr ipv6;
+  } netmask;
   in_port_t port;
   coc_address_type_t addr_type;
   coc_rule_type_t rule_type;
   SLIST_ENTRY(coc_entry) entries;
+  bool is_subnet;
 } coc_entry_t;
 
 static inline
@@ -333,12 +338,61 @@ strndup (const char *s, size_t n)
 }
 #endif
 
+
+static inline void
+mask_ipv4 (struct in_addr *addr, const struct in_addr *netmask)
+{
+  addr->s_addr &= netmask->s_addr;
+}
+
+static inline void
+mask_ipv6 (struct in6_addr *addr, const struct in6_addr *netmask)
+{
+  uint32_t *_addr = (uint32_t *) addr;
+  const uint32_t *_netmask = (uint32_t *) netmask;
+
+  for (int i = 0; i < 4; i++)
+    {
+      _addr[i] &= _netmask[i];
+    }
+}
+
+static void
+make_ipv4_netmask (struct in_addr *netmask, uint8_t cidr_prefix_length)
+{
+  memset (netmask, 0, sizeof(struct in_addr));
+
+  if (cidr_prefix_length > 0)
+    {
+      netmask->s_addr = htonl (0xFFFFFFFFu << (32u - cidr_prefix_length));
+    }
+}
+
+static void
+make_ipv6_netmask (struct in6_addr *netmask, uint8_t cidr_prefix_length)
+{
+  memset (netmask, 0, sizeof(struct in6_addr));
+
+  uint8_t *p_netmask = netmask->s6_addr;
+  while (8 < cidr_prefix_length)
+    {
+      *p_netmask = 0xFFu;
+      p_netmask++;
+      cidr_prefix_length -= 8;
+    }
+  if (cidr_prefix_length > 0)
+    {
+      *p_netmask = (0xFFu << (8u - cidr_prefix_length));
+    }
+}
+
 static int
-coc_rule_add (const char *str, size_t len, size_t rule_type)
+coc_rule_add (const char * const str, const size_t len, const size_t rule_type)
 {
   int type = COC_IPV4_ADDR | COC_IPV6_ADDR | COC_GLOB_ADDR | COC_HOST_ADDR;
   const char *p = str;
   const char *service = NULL;
+  const char *cidr_prefix_length_start = NULL;
   enum
   {
     IPV6_SB_NONE,
@@ -471,7 +525,7 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 
       else if (isdigit (c))
 	{
-	  if ((type & COC_IPV4_ADDR) == COC_IPV4_ADDR)
+	  if ((type & COC_IPV4_ADDR) == COC_IPV4_ADDR && cidr_prefix_length_start == NULL)
 	    {
 	      /* INT30-C */
 	      if ((segment > UINT16_MAX / 10) ||
@@ -534,6 +588,19 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 	  else
 	    {
 	      type &= ~(COC_IPV4_ADDR | COC_IPV6_ADDR);
+	    }
+	}
+
+      else if (c == '/')
+	{
+	  if (!(type & (COC_IPV4_ADDR | COC_IPV6_ADDR)) || cidr_prefix_length_start != NULL)
+	    {
+	      DIE ("`%c' unexpected, aborting\n", c);
+	    }
+	  else
+	    {
+	      cidr_prefix_length_start = p + 1;
+	      type &= (COC_IPV4_ADDR | COC_IPV6_ADDR);
 	    }
 	}
 
@@ -634,17 +701,68 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 	}
     }
 
-  char *host = NULL;
-  size_t skip_last = 1;
-
-  if (sb == IPV6_SB_CLOSE)
+  uint8_t cidr_prefix_length = 0;
+  if (cidr_prefix_length_start != NULL)
     {
-      str++;
-      len--;
-      skip_last = 2;
+      const char *p_end = str + len;
+
+      if (service != NULL)
+	{
+	  p_end = service - 1;
+	}
+      if (sb == IPV6_SB_CLOSE)
+	{
+	  p_end--;
+	}
+
+      if (p_end - cidr_prefix_length_start <= 0)
+	{
+	  DIE ("No CIDR prefix length specified after `/', aborting\n");
+	}
+      else if (p_end - cidr_prefix_length_start > 3)
+	{
+	  DIE ("Too long CIDR prefix length, aborting\n");
+	}
+
+      const char *t;
+      for (t = cidr_prefix_length_start; t < p_end; t++)
+	{
+	  unsigned char u = *t;
+
+	  if (!isdigit (u))
+	    {
+	      DIE ("`%c' unexpected for CIDR prefix length, aborting\n", u);
+	    }
+
+	  cidr_prefix_length = cidr_prefix_length * 10 + (u - '0');
+	}
+
+      if ((type == COC_IPV4_ADDR && cidr_prefix_length > 32) ||
+	  (type == COC_IPV6_ADDR && cidr_prefix_length > 128))
+	{
+	  DIE ("`%u' not allowed for CIDR prefix length, aborting\n", cidr_prefix_length);
+	}
     }
 
-  host = strndup (str, service ? service - str - skip_last : len);
+  const char *host_start = str;
+  const char *host_end = host_start + len;
+
+  if (service != NULL)
+    {
+      host_end = service - 1;
+    }
+  if (sb == IPV6_SB_CLOSE)
+    {
+      host_start++;
+      host_end--;
+    }
+  if (cidr_prefix_length_start != NULL)
+    {
+      host_end = cidr_prefix_length_start - 1;
+    }
+
+  size_t host_len = host_end - host_start;
+  char *host = strndup (host_start, host_len);
 
   coc_log (COC_DEBUG_LOG_LEVEL,
 	   "DEBUG Adding %s rule for %s connection to %s:%hu\n",
@@ -658,10 +776,17 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 	e->rule_type = rule_type;
 	e->addr_type = COC_IPV6_ADDR;
 	e->port = htons (port);
+	e->is_subnet = cidr_prefix_length_start != NULL;
 
 	if (inet_pton (AF_INET6, host, &e->addr.ipv6) != 1)
 	  {
 	    DIE ("Invalid IPv6 address: `%s', aborting\n", host);
+	  }
+
+	if (e->is_subnet)
+	  {
+	    make_ipv6_netmask (&e->netmask.ipv6, cidr_prefix_length);
+	    mask_ipv6 (&e->addr.ipv6, &e->netmask.ipv6);
 	  }
 
 	SLIST_INSERT_HEAD (&coc_list_head, e, entries);
@@ -675,10 +800,17 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 	e->rule_type = rule_type;
 	e->addr_type = COC_IPV4_ADDR;
 	e->port = htons (port);
+	e->is_subnet = cidr_prefix_length_start != NULL;
 
 	if (inet_pton (AF_INET, host, &e->addr.ipv4) != 1)
 	  {
 	    DIE ("Invalid IPv4 address: `%s', aborting\n", host);
+	  }
+
+	if (e->is_subnet)
+	  {
+	    make_ipv4_netmask (&e->netmask.ipv4, cidr_prefix_length);
+	    mask_ipv4 (&e->addr.ipv4, &e->netmask.ipv4);
 	  }
 
 	SLIST_INSERT_HEAD (&coc_list_head, e, entries);
@@ -692,6 +824,7 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 	e->rule_type = rule_type;
 	e->addr_type = COC_GLOB_ADDR;
 	e->port = htons (port);
+	e->is_subnet = false;
 	/* Here we transfer ownership of `host' to the entry. */
 	e->addr.glob = host;
 	SLIST_INSERT_HEAD (&coc_list_head, e, entries);
@@ -731,6 +864,7 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 		e->rule_type = rule_type;
 		e->addr_type = COC_IPV4_ADDR;
 		e->port = htons (port);
+		e->is_subnet = false;
 		e->addr.ipv4 = sa->sin_addr;
 		SLIST_INSERT_HEAD (&coc_list_head, e, entries);
 	      }
@@ -743,6 +877,7 @@ coc_rule_add (const char *str, size_t len, size_t rule_type)
 		e->rule_type = rule_type;
 		e->addr_type = COC_IPV6_ADDR;
 		e->port = htons (port);
+		e->is_subnet = false;
 		e->addr.ipv6 = sa->sin6_addr;
 		SLIST_INSERT_HEAD (&coc_list_head, e, entries);
 	      }
@@ -1244,6 +1379,36 @@ coc_init (void)
 
 static inline
 bool
+coc_rule_match_ipv4 (const struct in_addr *rule_addr, in_port_t rule_port, const struct in_addr *addr, in_port_t port, bool rule_is_subnet, const struct in_addr *netmask)
+{
+  struct in_addr masked_addr;
+  if (rule_is_subnet)
+    {
+      masked_addr = *addr;
+      mask_ipv4 (&masked_addr, netmask);
+      addr = &masked_addr;
+    }
+  return (rule_addr->s_addr == addr->s_addr &&
+	  (!rule_port || rule_port == port));
+}
+
+static inline
+bool
+coc_rule_match_ipv6 (const struct in6_addr *rule_addr, in_port_t rule_port, const struct in6_addr *addr, in_port_t port, bool rule_is_subnet, const struct in6_addr *netmask)
+{
+  struct in6_addr masked_addr;
+  if (rule_is_subnet)
+    {
+      masked_addr = *addr;
+      mask_ipv6 (&masked_addr, netmask);
+      addr = &masked_addr;
+    }
+  return (IN6_ARE_ADDR_EQUAL (rule_addr, addr) &&
+	  (!rule_port || rule_port == port));
+}
+
+static inline
+bool
 coc_rule_match (coc_entry_t *e, const struct sockaddr *addr, const char *buf)
 {
   switch (e->addr_type)
@@ -1251,15 +1416,25 @@ coc_rule_match (coc_entry_t *e, const struct sockaddr *addr, const char *buf)
     case COC_IPV6_ADDR:
       if (addr->sa_family == AF_INET6)
 	{
-	  return (IN6_ARE_ADDR_EQUAL (&e->addr.ipv6, INET6_ADDR (addr)) &&
-		  (!e->port || e->port == INET6_PORT (addr)));
+	  return coc_rule_match_ipv6 (
+		  &e->addr.ipv6,
+		  e->port,
+		  INET6_ADDR (addr),
+		  INET6_PORT (addr),
+		  e->is_subnet,
+		  &e->netmask.ipv6);
 	}
       else if (addr->sa_family == AF_INET)
 	{
 	  if (IN6_IS_ADDR_V4MAPPED (&e->addr.ipv6))
 	    {
-	      return (INET4_IN_6 (&e->addr.ipv6)->s_addr == INET4_ADDR (addr)->s_addr &&
-		      (!e->port || e->port == INET4_PORT (addr)));
+	      return coc_rule_match_ipv4 (
+		      INET4_IN_6 (&e->addr.ipv6),
+		      e->port,
+		      INET4_ADDR (addr),
+		      INET4_PORT (addr),
+		      e->is_subnet,
+		      INET4_IN_6 (&e->netmask.ipv6));
 	    }
 	}
       break;
@@ -1267,15 +1442,25 @@ coc_rule_match (coc_entry_t *e, const struct sockaddr *addr, const char *buf)
     case COC_IPV4_ADDR:
       if (addr->sa_family == AF_INET)
 	{
-	  return (e->addr.ipv4.s_addr == INET4_ADDR (addr)->s_addr &&
-		  (!e->port || e->port == INET4_PORT (addr)));
+	  return coc_rule_match_ipv4 (
+		  &e->addr.ipv4,
+		  e->port,
+		  INET4_ADDR (addr),
+		  INET4_PORT (addr),
+		  e->is_subnet,
+		  &e->netmask.ipv4);
 	}
       else if (addr->sa_family == AF_INET6)
 	{
 	  if (IN6_IS_ADDR_V4MAPPED (INET6_ADDR (addr)))
 	    {
-	      return (e->addr.ipv4.s_addr == INET4_IN_6 (INET6_ADDR (addr))->s_addr &&
-		      (!e->port || e->port == INET6_PORT (addr)));
+	      return coc_rule_match_ipv4 (
+		      &e->addr.ipv4,
+		      e->port,
+		      INET4_IN_6 (INET6_ADDR (addr)),
+		      INET6_PORT (addr),
+		      e->is_subnet,
+		      &e->netmask.ipv4);
 	    }
 	}
       break;

--- a/testsuite
+++ b/testsuite
@@ -76,6 +76,7 @@ WD="`dirname $0`"
 test -f "$WD/tcpcontest" || _die "Missing tcpcontest helper program!"
 
 ALLOW host ::1 port 50 with args -a ::1 -b \'*\'
+ALLOW host ::1 port 50 with args -a [::1] -b \'*\'
 ALLOW host ::1 port 50 with args -a [::1]:50 -b \'*\'
 BLOCK host ::1 port 50 with args -a [::1]:49 -b \'*\'
 ALLOW host ::1 port 21 with args -a [::1]:ftp -b \'*\'
@@ -90,6 +91,14 @@ ALLOW host 127.0.0.1 port 50 with args -a \'*\'
 BLOCK host 127.0.0.1 port 50 with args -b \'*\'
 ALLOW host localhost port 50 with args -a localhost -b \'*\'
 BLOCK host localhost port 50 with args -a localhost:49 -b \'*\'
+ALLOW host 127.0.0.1 port 80 with args -a ::ffff:7f00:1 -b \'*\'
+BLOCK host 127.0.0.2 port 80 with args -a ::ffff:7f00:1 -b \'*\'
+ALLOW host 127.0.0.1 port 80 with args -a [::ffff:7f00:1]:80 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -a [::ffff:7f00:1]:81 -b \'*\'
+ALLOW host ::ffff:7f00:1 port 80 with args -a 127.0.0.1 -b \'*\'
+BLOCK host ::ffff:7f00:2 port 80 with args -a 127.0.0.1 -b \'*\'
+ALLOW host ::ffff:7f00:1 port 80 with args -a 127.0.0.1:80 -b \'*\'
+BLOCK host ::ffff:7f00:1 port 80 with args -a 127.0.0.1:81 -b \'*\'
 ALLOW host www.google.com port 80 with args -d -a \'*.google.com\' -a \'*.1e100.net\' -b \'*\'
 #ALLOW host lwn.net port 80 with args -a lwn.net:80 -b \'*\'
 ABORT_ON host www.google.com port 80 with args -a \'*.google.com\' -a \'*.1e100.net\' -b \'*\'
@@ -99,6 +108,183 @@ ABORT_ON host ::1 port 80 with args -a a::b::a
 ABORT_ON host ::1 port 80 with args -a fffff::
 ABORT_ON host localhost port 80 with args -a 256.168.10.192
 ABORT_ON host ::1 port 80 with args -a 256:fffff::
+
+
+# CIDR notation test
+
+## IPv4
+
+### Standard
+ALLOW host 127.0.0.1 port 80 with args -a 127.0.0.1 -b \'*\'
+ALLOW host 127.0.0.1 port 80 with args -a 127.0.0.1/24 -b \'*\'
+BLOCK host 127.0.1.1 port 80 with args -a 127.0.0.1/24 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -b 127.0.0.1
+
+### With port
+ALLOW host 127.0.0.1 port 80 with args -a 127.0.0.0/24:80 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -a 127.0.0.0/24:81 -b \'*\'
+BLOCK host 127.0.1.0 port 80 with args -a 127.0.0.0/24:80 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -b 127.0.0.0/24:80
+ALLOW host 127.0.0.0 port 21 with args -a 127.0.0.0/24:ftp -b \'*\'
+
+### Invalid syntax
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1/-1 -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1/33 -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1/a -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1/ -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1/24/24 -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0.1:80/24 -b \'*\'
+ABORT_ON host 127.0.0.1 port 80 with args -a 127.0.0/24.1 -b \'*\'
+
+### 32bit mask
+ALLOW host 127.0.0.1 port 80 with args -a 127.0.0.1/32 -b \'*\'
+BLOCK host 127.0.0.2 port 80 with args -a 127.0.0.1/32 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -a 0.0.0.0/32 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -a 255.255.255.255/32 -b \'*\'
+
+### 31bit mask
+BLOCK host 127.0.0.1 port 80 with args -a 127.0.0.2/31 -b \'*\'
+ALLOW host 127.0.0.2 port 80 with args -a 127.0.0.2/31 -b \'*\'
+ALLOW host 127.0.0.3 port 80 with args -a 127.0.0.2/31 -b \'*\'
+BLOCK host 127.0.0.4 port 80 with args -a 127.0.0.2/31 -b \'*\'
+
+### 1bit mask
+ALLOW host 1.0.0.0 port 80 with args -a 127.0.0.0/1 -b \'*\'
+ALLOW host 127.255.255.255 port 80 with args -a 127.0.0.0/1 -b \'*\'
+BLOCK host 128.0.0.1 port 80 with args -a 127.0.0.0/1 -b \'*\'
+BLOCK host 255.255.255.255 port 80 with args -a 127.0.0.0/1 -b \'*\'
+
+### 0bit mask
+ALLOW host 0.0.0.1 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 0.0.1.0 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 0.1.0.0 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 1.0.0.0 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 127.255.255.255 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 128.0.0.1 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 255.255.255.255 port 80 with args -a 127.0.0.0/0 -b \'*\'
+ALLOW host 127.0.0.1 port 80 with args -a 0.0.0.0/0 -b \'*\'
+ALLOW host 127.0.0.1 port 80 with args -a 255.255.255.255/0 -b \'*\'
+
+## IPv6
+
+### Standard
+ALLOW host ::1 port 80 with args -a ::1 -b \'*\'
+ALLOW host ::1 port 80 with args -a ::1/24 -b \'*\'
+ALLOW host ::1 port 80 with args -a [::1/24] -b \'*\'
+BLOCK host a::1 port 80 with args -a ::1/24 -b \'*\'
+BLOCK host ::1 port 80 with args -b ::1
+
+### With port
+ALLOW host ::1 port 80 with args -a [::1/24]:80 -b \'*\'
+BLOCK host ::1 port 80 with args -a [::1/24]:81 -b \'*\'
+BLOCK host a::1 port 80 with args -a [::1/24]:80 -b \'*\'
+BLOCK host ::1 port 80 with args -b [::1/24]:80
+ALLOW host ::1 port 21 with args -a [::1/24]:ftp -b \'*\'
+
+### Invalid syntax
+ABORT_ON host ::1 port 80 with args -a ::1/-1 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a ::1/129 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a ::1/a -b \'*\'
+ABORT_ON host ::1 port 80 with args -a ::1/ -b \'*\'
+ABORT_ON host ::1 port 80 with args -a ::1/24/24 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a [::1]/24 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a [::1/24/24] -b \'*\'
+ABORT_ON host ::1 port 80 with args -a [::1/24]:80:80 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a [::1]:80/24 -b \'*\'
+ABORT_ON host ::1 port 80 with args -a [:1:/24:1] -b \'*\'
+ABORT_ON host ::1 port 80 with args -a /24[::1] -b \'*\'
+
+### 128bit mask
+ALLOW host ::1 port 80 with args -a ::1/128 -b \'*\'
+BLOCK host ::2 port 80 with args -a ::1/128 -b \'*\'
+BLOCK host ::1 port 80 with args -a ::0/128 -b \'*\'
+BLOCK host ::1 port 80 with args -a 2001:db8:0:1:1:1:1:1/128 -b \'*\'
+ALLOW host 2001:db8:0:1:1:1:1:1 port 80 with args -a 2001:db8:0:1:1:1:1:1/128 -b \'*\'
+
+### 127bit mask
+BLOCK host ::1 port 80 with args -a ::2/127 -b \'*\'
+ALLOW host ::2 port 80 with args -a ::2/127 -b \'*\'
+ALLOW host ::3 port 80 with args -a ::2/127 -b \'*\'
+BLOCK host ::4 port 80 with args -a ::2/127 -b \'*\'
+
+### 1bit mask
+BLOCK host ::0 port 80 with args -a 8000::/1 -b \'*\'
+BLOCK host 7fff:ffff:ffff:ffff:ffff:ffff:ffff:ffff port 80 with args -a 8000::/1 -b \'*\'
+ALLOW host 8000:: port 80 with args -a 8000::/1 -b \'*\'
+ALLOW host ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff port 80 with args -a 8000::/1 -b \'*\'
+
+### 0bit mask
+ALLOW host 2001:db8:0:1:1:1:1:1 port 80 with args -a 8000::/0 -b \'*\'
+ALLOW host ::0 port 80 with args -a 8000::/0 -b \'*\'
+ALLOW host ::1 port 80 with args -a 8000::/0 -b \'*\'
+ALLOW host ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff port 80 with args -a 8000::/0 -b \'*\'
+ALLOW host ::1 port 80 with args -a ::0/0 -b \'*\'
+ALLOW host ::1 port 80 with args -a ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff/0 -b \'*\'
+
+## Rule IP is IPv4 mapping
+
+### With port
+ALLOW host 127.1.1.1 port 80 with args -a [::ffff:7f01:101/128]:80 -b \'*\'
+BLOCK host 127.1.1.1 port 80 with args -a [::ffff:7f01:101/128]:81 -b \'*\'
+
+### 128bit mask
+ALLOW host 127.1.1.1 port 80 with args -a ::ffff:7f01:101/128 -b \'*\'
+BLOCK host 127.1.1.2 port 80 with args -a ::ffff:7f01:101/128 -b \'*\'
+BLOCK host 128.1.1.1 port 80 with args -a ::ffff:7f01:101/128 -b \'*\'
+
+### 127bit mask
+BLOCK host 127.0.0.1 port 80 with args -a ::ffff:7f00:2/127 -b \'*\'
+ALLOW host 127.0.0.2 port 80 with args -a ::ffff:7f00:2/127 -b \'*\'
+ALLOW host 127.0.0.3 port 80 with args -a ::ffff:7f00:2/127 -b \'*\'
+BLOCK host 127.0.0.4 port 80 with args -a ::ffff:7f00:2/127 -b \'*\'
+
+### 97bit mask
+ALLOW host 1.0.0.0 port 80 with args -a ::ffff:7f01:101/97 -b \'*\'
+ALLOW host 127.255.255.255 port 80 with args -a ::ffff:7f01:101/97 -b \'*\'
+BLOCK host 128.0.0.0 port 80 with args -a ::ffff:7f01:101/97 -b \'*\'
+
+### 96bit mask
+ALLOW host 127.0.0.1 port 80 with args -a ::ffff:7f01:101/96 -b \'*\'
+ALLOW host 128.1.1.2 port 80 with args -a ::ffff:7f01:101/96 -b \'*\'
+
+### These are not treated as ipv4 mapped address because the rule side is masked.
+BLOCK host 127.0.0.1 port 80 with args -a ::ffff:7f00:1/0 -b \'*\'
+BLOCK host 127.0.0.1 port 80 with args -a ::ffff:7f00:1/95 -b \'*\'
+
+## Connect IP is IPv4 mapping
+
+### With port
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.1.1.1/32:80 -b \'*\'
+BLOCK host ::ffff:7f01:101 port 80 with args -a 127.1.1.1/32:81 -b \'*\'
+
+### 32bit mask
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.1.1.1/32 -b \'*\'
+BLOCK host ::ffff:7f01:101 port 80 with args -a 127.1.1.2/32 -b \'*\'
+BLOCK host ::ffff:7f01:101 port 80 with args -a 128.1.1.1/32 -b \'*\'
+BLOCK host ::ffff:7f01:102 port 80 with args -a 127.1.1.1/32 -b \'*\'
+
+### 31bit mask
+BLOCK host ::ffff:7f01:102 port 80 with args -a 127.1.1.1/31 -b \'*\'
+ALLOW host ::ffff:7f01:102 port 80 with args -a 127.1.1.2/31 -b \'*\'
+ALLOW host ::ffff:7f01:102 port 80 with args -a 127.1.1.3/31 -b \'*\'
+BLOCK host ::ffff:7f01:102 port 80 with args -a 127.1.1.4/31 -b \'*\'
+
+### 1bit mask
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.1.1.1/1 -b \'*\'
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.1.1.2/1 -b \'*\'
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.1.2.1/1 -b \'*\'
+ALLOW host ::ffff:7f01:101 port 80 with args -a 127.2.1.1/1 -b \'*\'
+BLOCK host ::ffff:7f01:101 port 80 with args -a 128.1.1.1/1 -b \'*\'
+
+### 0bit mask
+ALLOW host ::ffff:101:101 port 80 with args -a 127.1.1.1/0 -b \'*\'
+ALLOW host ::ffff:ffff:ffff port 80 with args -a 127.1.1.1/0 -b \'*\'
+
+## hostname
+
+### Invalid syntax
+ABORT_ON host localhost port 80 with args -a localhost/24 -b \'*\'
+
 
 if test $ecount -gt 0; then
     _die "$ecount test(s) failed!"


### PR DESCRIPTION
I added CIDR notation support to coc. I'm glad if you merge.
Details are described below.
Thank you.

# Motivation

I wanted to restrict access to a specific private network.

# Changes

- Added CIDR notation support (e.g. --block=192.168.0.1/24)
  - like apache httpd.conf Allow, Deny

# Reason for this implementation

Even now it can be matched like 192.168.0. *, but it seems to be difficult to use because it must fail the reverse dns lookup.
I also considered the option to stop reverse dns lookup, but I gave up because it is difficult to use with a host name glob match.

# Cons

The following notation is not standard.

```
ip/prefix:port
```

But, it is convenient to allow specific ports with ip range...

# Test

All tests passed on my 64 bit linux PC (Intel CPU).
