### PR TITLE
Add test binary (speed up the test)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ ABI := 1
 VER := $(ABI).0.4
 LIB := libconnect-or-cut.so
 TGT := $(LIB).$(VER)
+OBJ_FOR_TEST := $(SRC:.c=_test.o)
+LIB_FOR_TEST := libconnect-or-cut_test.so
+TGT_FOR_TEST := $(LIB_FOR_TEST).$(VER)
+LNK_FOR_TEST := $(LIB_FOR_TEST).$(ABI)
 TST := tcpcontest
 LNK := $(LIB).$(ABI)
 
@@ -39,16 +43,24 @@ CPPFLAGS+= ${OPTION_STEALTH_${stealth}} ${${os}_CPPFLAGS}
 LDFLAGS += ${${os}__LDFLAGS} ${${bits}__LDFLAGS}
 
 .PHONY: all
-all: $(TGT) $(TST)
+all: $(TGT) $(TGT_FOR_TEST) $(TST)
 
 .PHONY: clean
 clean:
-	rm -f $(OBJ) $(TGT) $(LNK) $(TST) $(TST).o
+	rm -f $(OBJ) $(TGT) $(LNK) $(OBJ_FOR_TEST) $(TGT_FOR_TEST) $(LNK_FOR_TEST) $(TST) $(TST).o
 
 $(TGT): $(OBJ)
 	$(CC) -o $(TGT) $(OBJ) $(LDFLAGS) ${${os}_LIBFLAGS}
 	rm -f $(LNK)
 	ln -s $(TGT) $(LNK)
+
+$(OBJ_FOR_TEST): $(SRC)
+	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) -D COC_TEST_MODE -c $<
+
+$(TGT_FOR_TEST): $(OBJ_FOR_TEST)
+	$(CC) -o $(TGT_FOR_TEST) $(OBJ_FOR_TEST) $(LDFLAGS) ${${os}_LIBFLAGS}
+	rm -f $(LNK_FOR_TEST)
+	ln -s $(TGT_FOR_TEST) $(LNK_FOR_TEST)
 
 $(TST): $(TST).o
 	$(CC) -o $(TST) $(TST).o $(LDFLAGS)
@@ -62,5 +74,5 @@ install: $(TGT)
 	(cd $(DESTLIB) && rm -f $(LNK) && ln -s $(TGT) $(LNK))
 
 .PHONY: test
-test: $(TGT) $(TST)
+test: $(TGT_FOR_TEST) $(TST)
 	./testsuite

--- a/coc
+++ b/coc
@@ -52,6 +52,7 @@ case "${P}" in
 esac
 
 LIB="${P}libconnect-or-cut${EXT}"
+LIB_FOR_TEST="${P}libconnect-or-cut_test${EXT}"
 FLIB="${F}libconnect-or-cut${EXT}"
 
 _warn() {
@@ -272,6 +273,11 @@ while test $# -gt 0; do
 	    shift 2
 	    ;;
 
+	--test-mode)
+	    LIB=$LIB_FOR_TEST
+	    shift
+	    ;;
+
 	--log-target=*)
 	    _append_log_target "$1" "`_value $1`"
 	    shift
@@ -349,6 +355,7 @@ export COC_LOG_PATH
 _append_preload
 unset preload
 unset LIB
+unset LIB_FOR_TEST
 unset FLIB
 
 eval $OGLOB

--- a/connect-or-cut.c
+++ b/connect-or-cut.c
@@ -234,6 +234,11 @@ static bool needs_dns_lookup = false;
 static coc_log_level_t log_level = COC_BLOCK_LOG_LEVEL;
 static coc_log_target_t log_target = COC_STDERR_LOG;
 static char *log_file_name = NULL;
+#ifdef COC_TEST_MODE
+static bool test_mode = true;
+#else
+static bool test_mode = false;
+#endif
 
 #ifdef __GNUC__
 static void
@@ -1363,6 +1368,11 @@ HOOK(connect(SOCKET fd, const struct sockaddr *addr, socklen_t addrlen))
 	      {
 		coc_log (COC_ALLOW_LOG_LEVEL, "ALLOW connection to %s:%hu\n", str,
 			 ntohs (port));
+		if (test_mode)
+		  {
+		    errno = EACCES;
+		    return -1;
+		  }
 		return real_connect (fd, addr, addrlen);
 	      }
 	    else
@@ -1381,5 +1391,10 @@ HOOK(connect(SOCKET fd, const struct sockaddr *addr, socklen_t addrlen))
 	       ntohs (port));
     }
 
+  if (test_mode)
+    {
+      errno = EACCES;
+      return -1;
+    }
   return real_connect (fd, addr, addrlen);
  }

--- a/testsuite
+++ b/testsuite
@@ -36,7 +36,7 @@ _run() {
     shift 2
     port=$1
     shift 3
-    "$WD/coc" -t stderr $1 $2 $3 $4 $5 $6 $7 $8 $9 -- "$WD/tcpcontest" "$host" "$port"
+    "$WD/coc" --test-mode -t stderr $1 $2 $3 $4 $5 $6 $7 $8 $9 -- "$WD/tcpcontest" "$host" "$port"
 }
 
 _header() {


### PR DESCRIPTION
This is another version of #2.

I added test binary to coc and speed up the test.
Test binary actually blocks connections even if the result is ALLOW.
This is an option for coc development. (for testsuite)

# Motivation

- CIDR notation support (#1) increased the number of tests, so I wanted to speed up the test.
- I wanted to write a test without worrying about connecting to real IP.

# Difference from #2

I prepared a test binary and used it with coc's command line option(--test-mode).

- Pros
  - It is not affected by environment variables.
- Cons
  - Increase Makefile rule. (for test binary)

# Benchmark

On my computer.  With master HEAD(21b859ac70).
132 sec -> 3 sec.

## Without --test-mode option

```
$ time make test > /dev/null

real    2m12.778s
user    0m2.743s
sys     0m0.674s
```

## With --test-mode option

```
$ time make test > /dev/null

real    0m2.808s
user    0m2.738s
sys     0m0.650s
```


# Test results

## Without --test-mode option

The behavior of coc has not changed.

```
% ./coc -l allow -- ./tcpcontest 8.8.8.8 53
2019-01-28T11:37:45 ALLOW connection to 8.8.8.8:53
connect to 8.8.8.8 is OK

% ./coc -l allow -a "*" -- ./tcpcontest 8.8.8.8 53
2019-01-28T11:38:04 ALLOW connection to 8.8.8.8:53
connect to 8.8.8.8 is OK
```

see also
https://travis-ci.org/tgg/connect-or-cut/builds/436477149
> Total time 1 hr 59 sec

## With --test-mode option

The message is ALLOW, but it does not actually connect.

```
% ./coc --test-mode -l allow -- ./tcpcontest 8.8.8.8 53
2019-01-28T11:38:30 ALLOW connection to 8.8.8.8:53
connect to 8.8.8.8 is KO: errno is 13 (Permission denied)

% ./coc --test-mode -l allow -a "*" -- ./tcpcontest 8.8.8.8 53
2019-01-28T11:38:57 ALLOW connection to 8.8.8.8:53
connect to 8.8.8.8 is KO: errno is 13 (Permission denied)
```

see also
https://travis-ci.org/tgg/connect-or-cut/builds/485226270
> Total time 1 min 42 sec